### PR TITLE
Codeowner file syntax error resolution

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -47,5 +47,5 @@ Articles/VisualStudio_C_CPP/VisualStudioCrossCompilation.md @Yokogawa-BrigitteZa
 
 ## AzureIoTRuntimeEnvironment
 
-Articles\AzureIoTRuntimeEnvironment\Deploying_sample_Python_module.md @Yokogawa-BrigitteZacharia
-Articles\AzureIoTRuntimeEnvironment\CreatePythonDataCollection_AzureIoT.md @Yokogawa-Nilesh
+Articles/AzureIoTRuntimeEnvironment/Deploying_sample_Python_module.md @Yokogawa-BrigitteZacharia
+Articles/AzureIoTRuntimeEnvironment/CreatePythonDataCollection_AzureIoT.md @Yokogawa-Nilesh


### PR DESCRIPTION
Backslash (\) must not be used in the CODEOWNERS file. Replaced all instances with forward slash.